### PR TITLE
Support single-set-of-keys keybinds to open files

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ Here's an example key binding:
 
 `{ "keys": ["ctrl+k", "ctrl+p"], "command": "sxs_settings" }`
 
+#### Setting a Keyboard Shortcut to Open a Specific File
+
+You can also set up a keyboard shortcut to open a specific file by accessing `sxs_open_file`, a command which isn't available through the Command Palette and only exists for the purposes of creating such keyboard shortcuts.
+
+An example keybind is:
+
+```
+{ "keys": ["Alt+Shift+f8"], "command": "sxs_open_file",
+    "args": { "base_file": "Side-by-Side Settings/sxs_settings.sublime-settings" }
+}
+```
+
+Any number of such keybinds can be set, giving you access to the files you want with a single key stroke or set of keys and bypassing the Command Palette entirely.
+
 ## Plug-in Settings
 
 Side-by-Side Settings currently supports the following plug-in specific 

--- a/sxs_settings.py
+++ b/sxs_settings.py
@@ -105,3 +105,16 @@ class SxsSelectFileCommand(sublime_plugin.WindowCommand):
         if index == -1:
             return
         open_window(self.window, self.file_list[index])
+
+
+class SxsOpenFileCommand(sublime_plugin.WindowCommand):
+    """
+    This class just exists so that you can create a custom single keybind to open any file you want
+
+    Example:
+        { "keys": ["Alt+Shift+f8"], "command": "sxs_open_file",
+            "args": { "base_file": "Side-by-Side Settings/sxs_settings.sublime-settings" }
+        }
+    """
+    def run(self, base_file: str):
+        open_window(self.window, base_file)


### PR DESCRIPTION
I wanted to be able to make a single keybind to open a specific syntax file (in my case, for Mediawiker extension, but could be anything) and I couldn't figure out any way to do it as written so this PR enables it.

This is the command I'm using, and I put a more generic example in the docstring:

```python
	{ "keys": ["Alt+Shift+f8"], "command": "sxs_open_file",
	    "args": { "base_file": "Mediawiker/Mediawiker.sublime-settings" }
	}
```